### PR TITLE
[Feat/#73] token save 및 자동 로그인

### DIFF
--- a/app/src/main/java/org/memento/data/local/TokenDataStore.kt
+++ b/app/src/main/java/org/memento/data/local/TokenDataStore.kt
@@ -43,16 +43,16 @@ class TokenDataStore
         }
 
         companion object {
-            private const val TOKEN_KEY = "token_key"
+            private const val TOKEN_KEY = ""
             private val preferencesTokenKey = stringPreferencesKey(TOKEN_KEY)
 
-            private const val REFRESH_TOKEN_KEY = "refresh_token_key"
+            private const val REFRESH_TOKEN_KEY = ""
             private val preferencesRefreshTokenKey = stringPreferencesKey(REFRESH_TOKEN_KEY)
 
             val TEMPORARY_TOKEN: String
-                get() = BuildConfig.ACCESS_TOKEN.ifEmpty { "default_access_token" }
+                get() = BuildConfig.ACCESS_TOKEN.ifEmpty { "" }
 
             val TEMPORARY_REFRESH_TOKEN: String
-                get() = BuildConfig.REFRESH_TOKEN.ifEmpty { "default_refresh_token" }
+                get() = BuildConfig.REFRESH_TOKEN.ifEmpty { "" }
         }
     }

--- a/app/src/main/java/org/memento/data/local/TokenDataStore.kt
+++ b/app/src/main/java/org/memento/data/local/TokenDataStore.kt
@@ -43,10 +43,10 @@ class TokenDataStore
         }
 
         companion object {
-            private const val TOKEN_KEY = ""
+            private const val TOKEN_KEY = "TOKEN_KEY"
             private val preferencesTokenKey = stringPreferencesKey(TOKEN_KEY)
 
-            private const val REFRESH_TOKEN_KEY = ""
+            private const val REFRESH_TOKEN_KEY = "REFRESH_KEY"
             private val preferencesRefreshTokenKey = stringPreferencesKey(REFRESH_TOKEN_KEY)
 
             val TEMPORARY_TOKEN: String

--- a/app/src/main/java/org/memento/presentation/MainActivity.kt
+++ b/app/src/main/java/org/memento/presentation/MainActivity.kt
@@ -1,7 +1,6 @@
 package org.memento.presentation
 
 import android.os.Bundle
-import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
@@ -13,20 +12,14 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.tooling.preview.Preview
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
-import org.memento.data.local.TokenDataStore
 import org.memento.presentation.main.MainScreen
 import org.memento.presentation.navigator.MainNavigator
-import org.memento.presentation.navigator.component.BottomNavigationType
 import org.memento.presentation.navigator.rememberMainNavigator
-import org.memento.presentation.onboarding.LoginScreen
 import org.memento.presentation.onboarding.SplashScreen
 import org.memento.ui.theme.MEMENTOTheme
-import timber.log.Timber
-import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
-
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 

--- a/app/src/main/java/org/memento/presentation/MainActivity.kt
+++ b/app/src/main/java/org/memento/presentation/MainActivity.kt
@@ -1,6 +1,7 @@
 package org.memento.presentation
 
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.runtime.Composable
@@ -12,14 +13,20 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.tooling.preview.Preview
 import dagger.hilt.android.AndroidEntryPoint
 import kotlinx.coroutines.delay
+import org.memento.data.local.TokenDataStore
 import org.memento.presentation.main.MainScreen
 import org.memento.presentation.navigator.MainNavigator
+import org.memento.presentation.navigator.component.BottomNavigationType
 import org.memento.presentation.navigator.rememberMainNavigator
+import org.memento.presentation.onboarding.LoginScreen
 import org.memento.presentation.onboarding.SplashScreen
 import org.memento.ui.theme.MEMENTOTheme
+import timber.log.Timber
+import javax.inject.Inject
 
 @AndroidEntryPoint
 class MainActivity : ComponentActivity() {
+
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
 
@@ -28,9 +35,7 @@ class MainActivity : ComponentActivity() {
             var showSplash by remember { mutableStateOf(true) }
             val navigator: MainNavigator = rememberMainNavigator()
 
-            MEMENTOTheme(
-                darkTheme = isDarkMode,
-            ) {
+            MEMENTOTheme(darkTheme = isDarkMode) {
                 LaunchedEffect(Unit) {
                     delay(SPLASH_SCREEN_DELAY)
                     showSplash = false

--- a/app/src/main/java/org/memento/presentation/onboarding/LoginScreen.kt
+++ b/app/src/main/java/org/memento/presentation/onboarding/LoginScreen.kt
@@ -57,7 +57,7 @@ fun LoginScreen(
 ) {
     val token by viewModel.token.collectAsState()
 
-    LaunchedEffect(Unit) {
+    LaunchedEffect(token) {
         Log.e("Loginscree",token.toString())
         if (!token.isNullOrEmpty()) {
             navigationToMainScreen()

--- a/app/src/main/java/org/memento/presentation/onboarding/LoginScreen.kt
+++ b/app/src/main/java/org/memento/presentation/onboarding/LoginScreen.kt
@@ -1,7 +1,6 @@
 package org.memento.presentation.onboarding
 
 import android.app.Activity
-import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.IntentSenderRequest

--- a/app/src/main/java/org/memento/presentation/onboarding/LoginScreen.kt
+++ b/app/src/main/java/org/memento/presentation/onboarding/LoginScreen.kt
@@ -1,6 +1,7 @@
 package org.memento.presentation.onboarding
 
 import android.app.Activity
+import android.util.Log
 import androidx.activity.compose.rememberLauncherForActivityResult
 import androidx.activity.result.ActivityResult
 import androidx.activity.result.IntentSenderRequest
@@ -38,18 +39,30 @@ import com.google.android.gms.common.api.ApiException
 import org.memento.BuildConfig
 import org.memento.R
 import org.memento.core.util.UiState
+import org.memento.data.local.TokenDataStore
 import org.memento.domain.entity.UserInfo
+import org.memento.presentation.main.MainScreen
 import org.memento.presentation.onboarding.component.SocialLoginButton
 import org.memento.presentation.onboarding.viewmodel.LoginViewModel
 import org.memento.presentation.util.noRippleClickable
 import org.memento.ui.theme.darkModeColors
 import org.memento.ui.theme.defaultMementoTypography
+import timber.log.Timber
 
 @Composable
 fun LoginScreen(
     viewModel: LoginViewModel = hiltViewModel(),
     navigationToOnboardingScreen1: () -> Unit,
+    navigationToMainScreen: () -> Unit,
 ) {
+    val token by viewModel.token.collectAsState()
+
+    LaunchedEffect(Unit) {
+        Log.e("Loginscree",token.toString())
+        if (!token.isNullOrEmpty()) {
+            navigationToMainScreen()
+        }
+    }
     var webViewVisible by remember { mutableStateOf(false) }
 
     val user by viewModel.user.collectAsState()
@@ -108,9 +121,9 @@ fun LoginScreen(
 
     Column(
         modifier =
-            Modifier
-                .fillMaxSize()
-                .padding(top = 130.dp, bottom = 176.dp),
+        Modifier
+            .fillMaxSize()
+            .padding(top = 130.dp, bottom = 176.dp),
         verticalArrangement = Arrangement.Center,
         Alignment.CenterHorizontally,
     ) {
@@ -153,10 +166,10 @@ fun LoginScreen(
                 style = defaultMementoTypography.detail_r_11,
                 color = darkModeColors.gray04,
                 modifier =
-                    Modifier
-                        .noRippleClickable {
-                            webViewVisible = true
-                        },
+                Modifier
+                    .noRippleClickable {
+                        webViewVisible = true
+                    },
             )
         }
     }

--- a/app/src/main/java/org/memento/presentation/onboarding/LoginScreen.kt
+++ b/app/src/main/java/org/memento/presentation/onboarding/LoginScreen.kt
@@ -39,15 +39,12 @@ import com.google.android.gms.common.api.ApiException
 import org.memento.BuildConfig
 import org.memento.R
 import org.memento.core.util.UiState
-import org.memento.data.local.TokenDataStore
 import org.memento.domain.entity.UserInfo
-import org.memento.presentation.main.MainScreen
 import org.memento.presentation.onboarding.component.SocialLoginButton
 import org.memento.presentation.onboarding.viewmodel.LoginViewModel
 import org.memento.presentation.util.noRippleClickable
 import org.memento.ui.theme.darkModeColors
 import org.memento.ui.theme.defaultMementoTypography
-import timber.log.Timber
 
 @Composable
 fun LoginScreen(
@@ -58,7 +55,6 @@ fun LoginScreen(
     val token by viewModel.token.collectAsState()
 
     LaunchedEffect(token) {
-        Log.e("Loginscree",token.toString())
         if (!token.isNullOrEmpty()) {
             navigationToMainScreen()
         }
@@ -121,9 +117,9 @@ fun LoginScreen(
 
     Column(
         modifier =
-        Modifier
-            .fillMaxSize()
-            .padding(top = 130.dp, bottom = 176.dp),
+            Modifier
+                .fillMaxSize()
+                .padding(top = 130.dp, bottom = 176.dp),
         verticalArrangement = Arrangement.Center,
         Alignment.CenterHorizontally,
     ) {
@@ -166,10 +162,10 @@ fun LoginScreen(
                 style = defaultMementoTypography.detail_r_11,
                 color = darkModeColors.gray04,
                 modifier =
-                Modifier
-                    .noRippleClickable {
-                        webViewVisible = true
-                    },
+                    Modifier
+                        .noRippleClickable {
+                            webViewVisible = true
+                        },
             )
         }
     }

--- a/app/src/main/java/org/memento/presentation/onboarding/navigation/OnboardingNavigation.kt
+++ b/app/src/main/java/org/memento/presentation/onboarding/navigation/OnboardingNavigation.kt
@@ -4,7 +4,6 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
-import org.memento.data.local.TokenDataStore
 import org.memento.presentation.onboarding.LoginScreen
 import org.memento.presentation.onboarding.OnboardingScreen1
 import org.memento.presentation.onboarding.OnboardingScreen2

--- a/app/src/main/java/org/memento/presentation/onboarding/navigation/OnboardingNavigation.kt
+++ b/app/src/main/java/org/memento/presentation/onboarding/navigation/OnboardingNavigation.kt
@@ -4,6 +4,7 @@ import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.NavOptions
 import androidx.navigation.compose.composable
+import org.memento.data.local.TokenDataStore
 import org.memento.presentation.onboarding.LoginScreen
 import org.memento.presentation.onboarding.OnboardingScreen1
 import org.memento.presentation.onboarding.OnboardingScreen2
@@ -37,6 +38,7 @@ fun NavGraphBuilder.onboardingNavGraph(
     composable("LoginScreen") {
         LoginScreen(
             navigationToOnboardingScreen1 = navigateToOnboardingScreen1,
+            navigationToMainScreen = navigateToMainScreen,
         )
     }
     composable("OnboardingScreen1") {

--- a/app/src/main/java/org/memento/presentation/onboarding/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/org/memento/presentation/onboarding/viewmodel/LoginViewModel.kt
@@ -20,60 +20,74 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel
-    @Inject
-    constructor(
-        private val authRepository: AuthRepository,
-        private val loginRepository: LoginRepository,
-        private val tokenDataStore: TokenDataStore,
-    ) : ViewModel() {
-        private val _user = MutableStateFlow<FirebaseUser?>(null)
-        val user = _user.asStateFlow()
+@Inject
+constructor(
+    private val authRepository: AuthRepository,
+    private val loginRepository: LoginRepository,
+    private val tokenDataStore: TokenDataStore,
+) : ViewModel() {
+    private val _user = MutableStateFlow<FirebaseUser?>(null)
+    val user = _user.asStateFlow()
 
-        private val _uiState = MutableStateFlow<UiState<UserInfo>>(UiState.Loading)
-        val uiState: StateFlow<UiState<UserInfo>> = _uiState
+    private val _uiState = MutableStateFlow<UiState<UserInfo>>(UiState.Loading)
+    val uiState: StateFlow<UiState<UserInfo>> = _uiState
 
-        fun saveToken(
-            accessToken: String,
-            refreshToken: String,
-        ) {
-            viewModelScope.launch {
-                tokenDataStore.setAccessToken(accessToken)
-                tokenDataStore.setRefreshToken(refreshToken)
-            }
+    private val _token = MutableStateFlow<String?>(null)
+    val token: StateFlow<String?> = _token.asStateFlow()
+
+    init {
+        loadToken()
+    }
+
+    fun loadToken(
+    ) {
+        viewModelScope.launch {
+            _token.value = tokenDataStore.getAccessToken()
         }
+    }
 
-        fun postLogin(
-            idToken: String,
-            provider: String = "GOOGLE",
-        ) {
-            viewModelScope.launch {
-                _uiState.value = UiState.Loading
-                val result = loginRepository.postLogin(Login(idToken = idToken, provider = provider))
-                _uiState.value =
-                    result.fold(
-                        onSuccess = { data -> UiState.Success(data) },
-                        onFailure = { data ->
-                            Timber.tag("data").d(data.message.toString())
-                            UiState.Failure
-                        },
-                    )
-            }
+    fun saveToken(
+        accessToken: String,
+        refreshToken: String,
+    ) {
+        viewModelScope.launch {
+            tokenDataStore.setAccessToken(accessToken)
+            tokenDataStore.setRefreshToken(refreshToken)
         }
+    }
 
-        fun signInWithGoogle(idToken: String) {
-            viewModelScope.launch {
-                val result = authRepository.signInWithGoogle(idToken)
-                result.onSuccess { firebaseUser ->
-                    _user.update { firebaseUser }
-                }.onFailure {
-                    Timber.d("Google Login Failed ${it.message}")
-                }
-            }
+    fun postLogin(
+        idToken: String,
+        provider: String = "GOOGLE",
+    ) {
+        viewModelScope.launch {
+            _uiState.value = UiState.Loading
+            val result = loginRepository.postLogin(Login(idToken = idToken, provider = provider))
+            _uiState.value =
+                result.fold(
+                    onSuccess = { data -> UiState.Success(data) },
+                    onFailure = { data ->
+                        Timber.tag("data").d(data.message.toString())
+                        UiState.Failure
+                    },
+                )
         }
+    }
 
-        fun checkCurrentUser() {
-            viewModelScope.launch {
-                _user.update { authRepository.getCurrentUser() }
+    fun signInWithGoogle(idToken: String) {
+        viewModelScope.launch {
+            val result = authRepository.signInWithGoogle(idToken)
+            result.onSuccess { firebaseUser ->
+                _user.update { firebaseUser }
+            }.onFailure {
+                Timber.d("Google Login Failed ${it.message}")
             }
         }
     }
+
+    fun checkCurrentUser() {
+        viewModelScope.launch {
+            _user.update { authRepository.getCurrentUser() }
+        }
+    }
+}

--- a/app/src/main/java/org/memento/presentation/onboarding/viewmodel/LoginViewModel.kt
+++ b/app/src/main/java/org/memento/presentation/onboarding/viewmodel/LoginViewModel.kt
@@ -20,74 +20,73 @@ import javax.inject.Inject
 
 @HiltViewModel
 class LoginViewModel
-@Inject
-constructor(
-    private val authRepository: AuthRepository,
-    private val loginRepository: LoginRepository,
-    private val tokenDataStore: TokenDataStore,
-) : ViewModel() {
-    private val _user = MutableStateFlow<FirebaseUser?>(null)
-    val user = _user.asStateFlow()
+    @Inject
+    constructor(
+        private val authRepository: AuthRepository,
+        private val loginRepository: LoginRepository,
+        private val tokenDataStore: TokenDataStore,
+    ) : ViewModel() {
+        private val _user = MutableStateFlow<FirebaseUser?>(null)
+        val user = _user.asStateFlow()
 
-    private val _uiState = MutableStateFlow<UiState<UserInfo>>(UiState.Loading)
-    val uiState: StateFlow<UiState<UserInfo>> = _uiState
+        private val _uiState = MutableStateFlow<UiState<UserInfo>>(UiState.Loading)
+        val uiState: StateFlow<UiState<UserInfo>> = _uiState
 
-    private val _token = MutableStateFlow<String?>(null)
-    val token: StateFlow<String?> = _token.asStateFlow()
+        private val _token = MutableStateFlow<String?>(null)
+        val token: StateFlow<String?> = _token.asStateFlow()
 
-    init {
-        loadToken()
-    }
-
-    fun loadToken(
-    ) {
-        viewModelScope.launch {
-            _token.value = tokenDataStore.getAccessToken()
+        init {
+            loadToken()
         }
-    }
 
-    fun saveToken(
-        accessToken: String,
-        refreshToken: String,
-    ) {
-        viewModelScope.launch {
-            tokenDataStore.setAccessToken(accessToken)
-            tokenDataStore.setRefreshToken(refreshToken)
+        fun loadToken() {
+            viewModelScope.launch {
+                _token.value = tokenDataStore.getAccessToken()
+            }
         }
-    }
 
-    fun postLogin(
-        idToken: String,
-        provider: String = "GOOGLE",
-    ) {
-        viewModelScope.launch {
-            _uiState.value = UiState.Loading
-            val result = loginRepository.postLogin(Login(idToken = idToken, provider = provider))
-            _uiState.value =
-                result.fold(
-                    onSuccess = { data -> UiState.Success(data) },
-                    onFailure = { data ->
-                        Timber.tag("data").d(data.message.toString())
-                        UiState.Failure
-                    },
-                )
+        fun saveToken(
+            accessToken: String,
+            refreshToken: String,
+        ) {
+            viewModelScope.launch {
+                tokenDataStore.setAccessToken(accessToken)
+                tokenDataStore.setRefreshToken(refreshToken)
+            }
         }
-    }
 
-    fun signInWithGoogle(idToken: String) {
-        viewModelScope.launch {
-            val result = authRepository.signInWithGoogle(idToken)
-            result.onSuccess { firebaseUser ->
-                _user.update { firebaseUser }
-            }.onFailure {
-                Timber.d("Google Login Failed ${it.message}")
+        fun postLogin(
+            idToken: String,
+            provider: String = "GOOGLE",
+        ) {
+            viewModelScope.launch {
+                _uiState.value = UiState.Loading
+                val result = loginRepository.postLogin(Login(idToken = idToken, provider = provider))
+                _uiState.value =
+                    result.fold(
+                        onSuccess = { data -> UiState.Success(data) },
+                        onFailure = { data ->
+                            Timber.tag("data").d(data.message.toString())
+                            UiState.Failure
+                        },
+                    )
+            }
+        }
+
+        fun signInWithGoogle(idToken: String) {
+            viewModelScope.launch {
+                val result = authRepository.signInWithGoogle(idToken)
+                result.onSuccess { firebaseUser ->
+                    _user.update { firebaseUser }
+                }.onFailure {
+                    Timber.d("Google Login Failed ${it.message}")
+                }
+            }
+        }
+
+        fun checkCurrentUser() {
+            viewModelScope.launch {
+                _user.update { authRepository.getCurrentUser() }
             }
         }
     }
-
-    fun checkCurrentUser() {
-        viewModelScope.launch {
-            _user.update { authRepository.getCurrentUser() }
-        }
-    }
-}


### PR DESCRIPTION
## ✅ 𝗖𝗵𝗲𝗰𝗸-𝗟𝗶𝘀𝘁
- merge할 브랜치의 위치를 확인해 주세요(main❌/develop⭕)
- 리뷰가 필요한 경우 리뷰어를 지정해 주세요
- 리뷰는 (아직 미정)에 진행됩니다.
- P1 단계의 리뷰는 (아직 미정)까지 반영합니다.
- Approve된 PR은 assigner가 머지하고, 수정 요청이 온 경우 수정 후 다시 push를 합니다.

## 📌 𝗜𝘀𝘀𝘂𝗲𝘀
- closed #73 

## 📎𝗪𝗼𝗿𝗸 𝗗𝗲𝘀𝗰𝗿𝗶𝗽𝘁𝗶𝗼𝗻
- 저장된 토큰을 가진 유저는 자동 로그인 됩니다.
- Refresh Token 관련 API 연동 대신 DataStore에 저장하여 관리했습니다.
## 📷 𝗦𝗰𝗿𝗲𝗲𝗻𝘀𝗵𝗼𝘁

https://github.com/user-attachments/assets/da9013bf-b88e-4463-973c-566ac414efb7

## 💬 𝗧𝗼 𝗥𝗲𝘃𝗶𝗲𝘄𝗲𝗿𝘀
깜빡하는 현상은 Splash 에서 분기처리 하면 된다고 하네여
쌰라웃투 안 팟 장